### PR TITLE
Remove pyfits as requirement for intallation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name='flipper',
                         'numpy>=1.11.3',
                         'astropy>=1.3',
                         'matplotlib>=1.5.3',
-                        'pyfits',
                         'scipy>=0.18.1',
                         'astLib>=0.8.0'],
       zip_safe=False)


### PR DESCRIPTION
pyfits shouldn't be on installation requirements since it's deprecated and the libraries use now astropy.io.fits 